### PR TITLE
Issue template & config to point people filing issues to discussions

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Have an idea for Moonwalk?
+    url: https://github.com/OAI/sig-moonwalk/discussions
+    about: Please open or join a discussion instead of an issue!
+  - name: Want to chat about Moonwalk?
+    url: https://communityinviter.com/apps/open-api/openapi
+    about: "Please join the #sig-moonwalk channel on our Slack!"

--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,16 @@
+---
+name: ''
+about: Consider opening a discussion instead...
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+<!--
+During this early phase of Moonwalk work, issues should be reserved for defining, discussing, and tracking *known work items* with PR-able actions.
+
+If you want to suggest ideas, please consider starting a discussion instead!
+
+https://github.com/OAI/sig-moonwalk/discussions
+-->


### PR DESCRIPTION
We are not yet at the point where Moonwalk will be managed through issues.  This changes the new issue workflow to offer buttons pointing to GitHub discussions and/or Slack, along with a template that repeats the advice from #11 to open a discussion instead of an issue.

I somewhat strengthened #11's language with the criteria that issues need to be things we can resolve by PRs in the short term.