### PR TITLE
Try quoting to fix mysterious yaml error

### DIFF
--- a/.github/workflows/jekyll-gh-pages.yml
+++ b/.github/workflows/jekyll-gh-pages.yml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: >=20.12.1
+          node-version: ">=20.12.1"
       - run: npm install
       - name: Generate Editors draft
         shell: pwsh


### PR DESCRIPTION
It loads fine in python without the quoting, but the workflow is reporting a YAML syntax error.